### PR TITLE
fix: suppress pnpm status output in setup-playwright version check

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -20,7 +20,7 @@ runs:
         VERSION=""
         case "${{ inputs.package-manager }}" in
           pnpm)
-            VERSION=$(pnpm exec playwright --version 2>/dev/null | grep -oE '[0-9]+(\.[0-9]+)+') || true
+            VERSION=$(pnpm --silent exec playwright --version 2>/dev/null | grep -oE '[0-9]+(\.[0-9]+)+') || true
             ;;
           npm)
             VERSION=$(npm exec playwright -- --version 2>/dev/null | grep -oE '[0-9]+(\.[0-9]+)+') || true


### PR DESCRIPTION
## Problem

In pnpm 11, `pnpm exec playwright --version` prints a deps-status header to **stdout** before running the binary:
```
Already up to date
Done in 47ms using pnpm v11.1.3
```
The version regex `[0-9]+(\.[0-9]+)+` matched `11.1.3` (the pnpm version), causing the action to believe playwright was installed in projects where it isn't. The subsequent browser install step then failed with:
```
[ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL] Command "playwright" not found
```

## Fix

Add `--silent` to suppress pnpm's own output, so only the playwright binary's output reaches the grep.

## Test plan
- [ ] CI passes on repos without playwright (should skip setup)
- [ ] CI passes on repos with playwright (should install browsers)