### PR TITLE
fix: use node lts/* in release workflow

### DIFF
--- a/.github/workflows/pnpm-release-changeset.yml
+++ b/.github/workflows/pnpm-release-changeset.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: lts/*
           cache: pnpm
 
       - name: Install Dependencies


### PR DESCRIPTION
## Summary

`pnpm-release-changeset.yml` had `node-version: 24` hardcoded. Node 24 is not yet LTS (becomes LTS Oct 2026). Changed to `lts/*` (currently Node 22).

## Test plan
- [ ] Release workflows pass