### PR TITLE
feat: add secretless pnpm-release-changeset-oidc workflow

### DIFF
--- a/.github/workflows/pnpm-release-changeset-oidc.yml
+++ b/.github/workflows/pnpm-release-changeset-oidc.yml
@@ -1,0 +1,80 @@
+name: pnpm-release-changeset-oidc
+# Secretless variant of pnpm-release-changeset.yml.
+#
+# Differences from that workflow:
+#   - No CI_GITHUB_TOKEN. Uses the built-in GITHUB_TOKEN with elevated `permissions`.
+#     Trade-off: a PR opened with GITHUB_TOKEN does not trigger `on: pull_request`
+#     workflows, so the "version packages" PR gets no status checks. That is fine for a
+#     mechanical version + changelog bump, since the release job only runs after the
+#     push to the base branch has already been verified.
+#   - No NPM_TOKEN. Publishes via npm trusted publishing (OIDC), which also emits
+#     provenance attestations. Each package must have a trusted publisher registered at
+#     npmjs.com/package/<name>/access naming this repo and this workflow's filename.
+#
+# Personal (non-organization) accounts have no shared secret scope, so a repo under a
+# user namespace would otherwise need its own copy of every token. This workflow needs
+# none.
+on:
+  workflow_call:
+    inputs:
+      pnpm-version:
+        type: string
+        required: false
+      node-version:
+        type: string
+        required: false
+        default: lts/*
+    outputs:
+      published:
+        description: 'Whether the release was published'
+        value: ${{ jobs.release.outputs.published }}
+
+permissions:
+  # Mints the OIDC token npm exchanges for short-lived publish credentials.
+  id-token: write
+  # Lets changesets/action push the version branch and tags.
+  contents: write
+  # Lets changesets/action open the "version packages" PR.
+  pull-requests: write
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # Version comes from `packageManager` in package.json unless overridden.
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      # Trusted publishing requires npm 11.5.1+. Node LTS may ship an older npm.
+      - name: Ensure npm supports trusted publishing
+        run: |
+          npm install -g npm@latest
+          npm --version
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - run: pnpm build
+
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          commit: 'chore: version packages'
+          version: pnpm run version
+          publish: pnpm run release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a variant of `pnpm-release-changeset.yml` that needs **no repo secrets**.

Personal-namespace repos (`unional/*`) have no shared secret scope — unlike `clibuilder`/`cyberuni`/`repobuddy`, which define `CI_GITHUB_TOKEN` once at org level. So every `unional/*` repo needs its own copy of each token, and PATs expire on a timer.

This workflow removes both:

| | existing | this |
|---|---|---|
| GitHub auth | `CI_GITHUB_TOKEN` (PAT, expires) | built-in `GITHUB_TOKEN` + `permissions:` |
| npm auth | `NPM_TOKEN` (long-lived) | trusted publishing via OIDC |

**Trade-off:** a PR opened with `GITHUB_TOKEN` does not trigger `on: pull_request` workflows, so the "version packages" PR gets no status checks. Acceptable for a mechanical version + changelog bump that only runs after the base branch was already verified — but it is why this is added *alongside* the existing workflow rather than replacing it. Repos needing checks on the version PR keep using `pnpm-release-changeset.yml`.

Trusted publishing also emits provenance attestations for free, and requires npm >= 11.5.1 — hence the explicit npm upgrade step, since Node LTS may ship an older npm.

Consuming repos must register a trusted publisher at `npmjs.com/package/<name>/access` naming the repo and this workflow filename.

First consumer will be `unional/search-packages`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)