### PR TITLE
feat: add bun-release-changeset-oidc reusable workflow

### DIFF
--- a/.github/workflows/bun-release-changeset-oidc.yml
+++ b/.github/workflows/bun-release-changeset-oidc.yml
@@ -1,0 +1,103 @@
+name: bun-release-changeset-oidc
+# Secretless variant of bun-release-changeset.yml.
+#
+# Differences from that workflow:
+#   - No CI_GITHUB_TOKEN. Checkout and changesets/action both use the built-in
+#     GITHUB_TOKEN with elevated `permissions`. Trade-off: a PR opened with GITHUB_TOKEN
+#     does not trigger `on: pull_request` workflows, so the "version packages" PR gets no
+#     status checks. That is fine for a mechanical version + changelog bump, since the
+#     release job only runs after the push to the base branch has already been verified.
+#   - No NPM_TOKEN, and no hand-written .npmrc. Publishes via npm trusted publishing
+#     (OIDC), which also emits provenance attestations. Each package needs a trusted
+#     publisher registered at npmjs.com/package/<name>/access naming the repo and the
+#     *caller* workflow's filename (release.yml), not this file.
+#
+# WHY OIDC WORKS HERE, EVEN THOUGH `bun publish` DOES NOT SUPPORT IT:
+#
+# changesets does not publish with the package manager it installed with. Its
+# getPublishTool() returns pnpm only when pnpm is detected, and `{name: "npm"}` for
+# everything else — bun included. So `changeset publish` shells out to `npm publish`, and
+# the OIDC exchange happens inside the npm CLI, which does support trusted publishing.
+# Verified against @changesets/cli 2.31.1.
+#
+# The consequence is that npm, not bun, must be current: the "Ensure npm supports trusted
+# publishing" step below is load-bearing, not boilerplate.
+#
+# Deliberately NO `registry-url` on setup-node — unlike pnpm-release-changeset-oidc.yml,
+# which keeps it. That workflow publishes through `pnpm publish`; this one goes through
+# the npm CLI, which is the same path that made `registry-url` fatal on the
+# semantic-release workflows. With it, setup-node writes an .npmrc containing
+# `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`, and npm sees an auth directive
+# it cannot satisfy instead of reaching the OIDC exchange (semantic-release/npm#1069).
+#
+# The playwright and vsce steps from bun-release-changeset.yml are intentionally absent.
+# They serve repos that need a browser or publish a VS Code extension; a repo needing
+# them should add them to its own caller or ask for a variant.
+#
+# Added alongside bun-release-changeset.yml rather than replacing it, so repos that have
+# not migrated keep working.
+on:
+  workflow_call:
+    inputs:
+      bun-version:
+        type: string
+        required: false
+      node-version:
+        type: string
+        required: false
+        default: lts/*
+    outputs:
+      published:
+        description: 'Whether the release was published'
+        value: ${{ jobs.release.outputs.published }}
+
+permissions:
+  # Mints the OIDC token npm exchanges for short-lived publish credentials.
+  id-token: write
+  # Lets changesets/action push the version branch and tags. bun-release-changeset.yml
+  # declares `contents: read` because its pushes went out under CI_GITHUB_TOKEN instead.
+  contents: write
+  # Lets changesets/action open the "version packages" PR.
+  pull-requests: write
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ inputs.bun-version }}
+
+      # Load-bearing: changesets publishes through the npm CLI (see header), and trusted
+      # publishing requires npm 11.5.1+. Node LTS may ship an older npm.
+      - name: Ensure npm supports trusted publishing
+        run: |
+          npm install -g npm@latest
+          npm --version
+
+      - name: Install Dependencies
+        run: bun install
+
+      - run: bun run build
+
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          commit: 'chore: version packages'
+          version: bun run version
+          publish: bun run release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Secretless counterpart of `bun-release-changeset.yml`, which uses **both** `NPM_TOKEN` and `CI_GITHUB_TOKEN` and hand-writes an `.npmrc` containing the token.

Unblocks `find-installed-packages` — the only repo on the bun toolchain in either org — going secretless without first migrating off bun.

## Why OIDC works here, even though `bun publish` does not support it

This looked like a blocker: Bun's docs describe token auth and 2FA for `bun publish`, with **no** mention of OIDC, trusted publishing, or provenance.

It works anyway, because **changesets does not publish with the package manager it installed with.** From `@changesets/cli` 2.31.1:

```js
async function getPublishTool(cwd) {
  const pm = await detect({ cwd });
  if (!pm || pm.name !== "pnpm") return { name: "npm" };
  ...
}
```

Anything that is not pnpm — bun included — publishes through **`npm publish`**, so the OIDC exchange happens inside the npm CLI, which does support trusted publishing.

Two consequences, both encoded in the file:

1. **The npm upgrade step is load-bearing**, not boilerplate. Trusted publishing needs npm 11.5.1+, and it is npm rather than bun that must be current.
2. **No `registry-url` on `setup-node`** — unlike `pnpm-release-changeset-oidc.yml`, which keeps it. That workflow publishes via `pnpm publish`; this one goes through the npm CLI, which is exactly the path that made `registry-url` fatal on the semantic-release workflows. With it, setup-node writes an `.npmrc` containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` and npm hits an auth directive it cannot satisfy instead of reaching the OIDC exchange (semantic-release/npm#1069).

That divergence between the two changeset workflows is deliberate and commented in both. It is driven by which binary actually runs `publish`, not by the release tool.

## Other differences from `bun-release-changeset.yml`

- **`contents: write`** where the original declares `contents: read` — the original's pushes went out under `CI_GITHUB_TOKEN`, so the job's own token never needed it.
- **Playwright and vsce steps dropped.** They serve repos that need a browser or publish a VS Code extension, not this generic path. A repo needing them should add them to its own caller.

## Status

**Untested end to end** — no repo points at it yet. `find-installed-packages` is the intended first consumer. The npm-side OIDC mechanics are the same ones proven on `cyberuni/color-map` (2.0.7, 2.0.8, 2.1.0 with provenance); what is unproven is the bun install/build path and the changesets-through-npm publish under bun.

Added **alongside** `bun-release-changeset.yml`, so unmigrated repos keep working.