### PR TITLE
fix: restore changesets/action v1 and split into v1/v2 lines

### DIFF
--- a/.github/workflows/bun-release-changeset-oidc.yml
+++ b/.github/workflows/bun-release-changeset-oidc.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v2.0.0
+        uses: changesets/action@v1
         with:
           commit: 'chore: version packages'
           version: bun run version

--- a/.github/workflows/bun-release-changeset.yml
+++ b/.github/workflows/bun-release-changeset.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v2.0.0
+        uses: changesets/action@v1
         with:
           commit: 'chore: version packages'
           version: bun run version

--- a/.github/workflows/pnpm-release-changeset-oidc.yml
+++ b/.github/workflows/pnpm-release-changeset-oidc.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v2.0.0
+        uses: changesets/action@v1
         with:
           commit: 'chore: version packages'
           version: pnpm run version

--- a/.github/workflows/pnpm-release-changeset.yml
+++ b/.github/workflows/pnpm-release-changeset.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v2.0.0
+        uses: changesets/action@v1
         with:
           commit: 'chore: version packages'
           version: pnpm run version

--- a/.github/workflows/yarn-release-changeset-monorepo.yml
+++ b/.github/workflows/yarn-release-changeset-monorepo.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v2.0.0
+        uses: changesets/action@v1
         with:
           commit: 'chore: version packages'
           version: yarn version

--- a/.github/workflows/yarn-release-changeset.yml
+++ b/.github/workflows/yarn-release-changeset.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v2.0.0
+        uses: changesets/action@v1
         with:
           commit: 'chore: version packages'
           version: yarn version

--- a/.github/workflows/yarn2-library-release.yml
+++ b/.github/workflows/yarn2-library-release.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v2.0.0
+        uses: changesets/action@v1
         # with:
         #   # run `yarn` again to update peer dependency refs
         #   version: yarn changeset version && yarn

--- a/README.md
+++ b/README.md
@@ -6,6 +6,76 @@
 
 Use the workflow templates to create workflows for each repository.
 
+## Versioning
+
+### Which ref to pin
+
+**Pin a tag, never `@main`.** For the changesets release workflows, which tag
+depends on one thing — the major of `@changesets/cli` in your repo:
+
+| Your `@changesets/cli` | Pin | Because |
+| --- | --- | --- |
+| v2 | `@v1` | `*-release-changeset*.yml` uses `changesets/action@v1` |
+| v3 | `@v2` | `*-release-changeset*.yml` uses `changesets/action@v2` |
+
+```yaml
+jobs:
+  release:
+    uses: unional/.github/.github/workflows/pnpm-release-changeset.yml@v1
+```
+
+If you do not use those workflows, either tag works — every other workflow is
+byte-identical across the two.
+
+`v1` and `v2` are *moving* tags, re-pointed forward on each backward-compatible
+release within their line and never moved across a breaking change. Pin an exact
+version (`@v1.0.0`) if you want a ref that never moves, and accept bumping it by
+hand.
+
+Do **not** pin `@main`: every consumer on it takes every change the instant it
+merges, including breaking ones nobody reviewed.
+
+### Why there are two lines
+
+`changesets/action` and `@changesets/cli` are strictly paired, and the action
+enforces it at runtime:
+
+| `changesets/action` | works with | inputs |
+| --- | --- | --- |
+| `v1` | `@changesets/cli` v2 | `version`, `publish`, `commit` |
+| `v2` | `@changesets/cli` v3 | `version-script`, `publish-script`, `commit-message` |
+
+Run v2 against CLI v2 and it aborts: *"Changesets CLI v2 is not supported; use
+Changesets action v1 instead."* No single workflow serves both.
+
+Consumers are split across both majors, so the lines run in parallel rather than
+one being a deadline. Eleven consumers of `pnpm-release-changeset.yml` are on CLI
+v2 (`@v1`); `monorepo-template` and `stable-context` are on v3 (`@v2`).
+
+**Branch layout:** `main` is the v1 line; the v2 line lives on `v2.x`. A fix that
+applies to both is made on `main` and cherry-picked. When the last consumer
+reaches CLI v3, `v2.x` merges down and the v1 line retires.
+
+### Why this exists
+
+`.mergify.yml` auto-merges Renovate PRs, so bumps to the actions these workflows
+call land on `main` with no human in the loop — and under `@main` they reach
+every consumer immediately. That is not hypothetical: `changesets/action` v1 → v2
+was auto-merged and broke the release path of every changesets consumer at once.
+Tagging means such a bump lands on `main` and waits until someone cuts a release.
+
+### Cutting a release
+
+```sh
+git checkout main && git pull
+git tag -a v1.0.0 -m "v1.0.0" && git push origin v1.0.0
+gh release create v1.0.0 --generate-notes
+git tag -f v1 v1.0.0 && git push -f origin v1
+```
+
+Same from `v2.x` with `v2.0.0` / `v2`. Forgetting the last step makes the release
+invisible to everyone pinning the alias.
+
 [`.gitignore` for yarn](https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored)
 
 ## migrate to yarn PnP


### PR DESCRIPTION
Same defect, same fix as [repobuddy/.github#45](https://github.com/repobuddy/.github/pull/45). Found while fixing that one — these two repos share these workflows.

## What is broken

Renovate bumped `changesets/action` v1 → **v2** (7c50b05) and Mergify auto-merged it. That major renamed every input *and* added a hard check on the consumer's `@changesets/cli` major.

All seven changesets workflows here are on `@v2.0.0` while still passing the v1 input names, so six of them abort outright:

```
Error: The following inputs have been renamed:
- "publish" -> "publish-script"
- "version" -> "version-script"
- "commit"  -> "commit-mesage"
```

and all seven fail for consumers on CLI v2:

```
This version of the Changesets action is designed to work with Changesets CLI v3.
Changesets CLI v2 is not supported; use Changesets action v1 instead.
```

Every consumer pins `@main`, so every changesets release path in the org is broken right now. Most repos have not noticed because they have not released since.

## Why two lines, not one fix

`changesets/action` and `@changesets/cli` are strictly paired, and the action enforces it:

| action | works with | inputs |
| --- | --- | --- |
| `v1` | CLI v2 | `version`, `publish`, `commit` |
| `v2` | CLI v3 | `version-script`, `publish-script`, `commit-message` |

Consumers are split across both majors, so no single workflow serves them:

| `@changesets/cli` | Repos | Pin |
| --- | --- | --- |
| v3 | `monorepo-template` `^3.0.0`, `stable-context` `^3.0.0` | `@v2` |
| v2 | `assertron` `^2.26.2`, `async-fp` `^2.26.0`, `iso-error` `2.31.1`, `jest-watch-repeat` `^2.25.2`, `never-fail` `^2.25.0`, `path-equal` `^2.26.0`, `satisfier` `^2.26.2`, `standard-log` `^2.25.0`, `tersify` `^2.29.8`, `type-plus` `^2.29.8`, `unpartial` `^2.25.0` | `@v1` |

(`eslint-plugin-harmony` uses the workflow but declares no `@changesets/cli` dependency at all — worth a look separately; it belongs on `@v1` either way.)

## What this PR does

`main` becomes the **v1 line**: reverts all seven workflows to `changesets/action@v1`. That alone unbreaks the eleven CLI-v2 consumers, who stay correct on `@main` in the meantime.

Adds a README section documenting the scheme, the pin-by-CLI-major rule, and the release procedure.

The **v2 line** is on the pushed `v2.x` branch: all seven on `@v2.0.0` with renamed inputs. `yarn2-library-release.yml` keeps its commented-out `with:` block — no live inputs to rename there.

## After merge

```sh
git checkout main && git pull
git tag -a v1.0.0 -m "v1.0.0" && git push origin v1.0.0
gh release create v1.0.0 --generate-notes
git tag -f v1 v1.0.0 && git push -f origin v1

git checkout v2.x   # rebase onto main first if this PR is squashed
git tag -a v2.0.0 -m "v2.0.0" && git push origin v2.0.0
gh release create v2.0.0 --generate-notes
git tag -f v2 v2.0.0 && git push -f origin v2
```

Then `monorepo-template` and `stable-context` move to `@v2` — they are the two that stay broken until they do. The other eleven can move to `@v1` at leisure.

## Not fixed here

Mergify's `head~=^(?!major-)` guard is meant to hold majors back, but Renovate does not prefix these branches with `major-`, so it never matches and majors merge unreviewed. That is how this landed. Separate defect.
