### PR TITLE
ci: drop registry-url from the OIDC release setup-node steps

### DIFF
--- a/.github/workflows/bun-release-changeset-oidc.yml
+++ b/.github/workflows/bun-release-changeset-oidc.yml
@@ -23,12 +23,11 @@ name: bun-release-changeset-oidc
 # The consequence is that npm, not bun, must be current: the "Ensure npm supports trusted
 # publishing" step below is load-bearing, not boilerplate.
 #
-# Deliberately NO `registry-url` on setup-node — unlike pnpm-release-changeset-oidc.yml,
-# which keeps it. That workflow publishes through `pnpm publish`; this one goes through
-# the npm CLI, which is the same path that made `registry-url` fatal on the
-# semantic-release workflows. With it, setup-node writes an .npmrc containing
-# `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`, and npm sees an auth directive
-# it cannot satisfy instead of reaching the OIDC exchange (semantic-release/npm#1069).
+# Deliberately NO `registry-url` on setup-node, as in every other -oidc workflow here.
+# With it, setup-node writes an .npmrc containing
+# `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` that a secretless run can never
+# fill in, and the tooling sees an auth directive it cannot satisfy instead of reaching
+# the OIDC exchange (semantic-release/npm#1069).
 #
 # The playwright and vsce steps from bun-release-changeset.yml are intentionally absent.
 # They serve repos that need a browser or publish a VS Code extension; a repo needing

--- a/.github/workflows/pnpm-release-changeset-oidc.yml
+++ b/.github/workflows/pnpm-release-changeset-oidc.yml
@@ -52,11 +52,19 @@ jobs:
       # Version comes from `packageManager` in package.json unless overridden.
       - uses: pnpm/action-setup@v6
 
+      # No `registry-url:` on purpose. It only exists to write an auth stanza —
+      # `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` in a temp .npmrc — which
+      # this secretless workflow can never fill in. Every npm and pnpm invocation then
+      # warns "Failed to replace env in config", and worse, `changeset publish`'s
+      # "is this version already on the registry?" probe comes back empty, so it tries
+      # to publish an already-published version and dies on npm's E403
+      # "You cannot publish over the previously published versions". The registry itself
+      # is not at stake: npmjs.org is npm's default, and repos that care say so in their
+      # own .npmrc.
       - uses: actions/setup-node@v7
         with:
           node-version: ${{ inputs.node-version }}
           cache: pnpm
-          registry-url: https://registry.npmjs.org
 
       # Trusted publishing requires npm 11.5.1+. Node LTS may ship an older npm.
       - name: Ensure npm supports trusted publishing

--- a/.github/workflows/pnpm-release-semantic-oidc.yml
+++ b/.github/workflows/pnpm-release-semantic-oidc.yml
@@ -67,13 +67,15 @@ jobs:
         with:
           version: ${{ inputs.pnpm-version }}
 
-      # Deliberately NO `registry-url`, unlike pnpm-release-changeset-oidc.yml. With it,
+      # Deliberately NO `registry-url`, as in every other -oidc workflow here. With it,
       # setup-node writes an .npmrc containing
       # `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` and points
       # NPM_CONFIG_USERCONFIG at it. That file is the documented cause of the spurious
       # `ENONPMTOKEN: No npm token specified` reports in semantic-release/npm#1069 —
       # npm sees an auth directive it cannot satisfy and never reaches the OIDC exchange.
-      # The changesets path is unaffected, which is why that workflow keeps it.
+      # The changesets workflows dropped it for the same reason: there the empty
+      # `${NODE_AUTH_TOKEN}` made `changeset publish`'s already-published probe come
+      # back empty, so it republished and died on E403.
       # @semantic-release/npm writes its own .npmrc, so nothing here needs one.
       - uses: actions/setup-node@v7
         with:


### PR DESCRIPTION
`registry-url` exists only to write `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into a temp `.npmrc`, which a secretless (OIDC) workflow can never fill in.

The comment in `pnpm-release-changeset-oidc.yml` claimed the changesets path was unaffected because it publishes through `pnpm publish`. It is not. `changeset publish`'s "is this version already on the registry?" probe reads the same `.npmrc`, comes back empty, and republishes an already-published version:

```
🦋  info gherkin-cli is being published because our local version (0.2.0) has not been published on npm
🦋  error You cannot publish over the previously published versions: 0.2.0.
 WARN  Issue while reading "/home/runner/work/_temp/.npmrc". Failed to replace env in config: ${NODE_AUTH_TOKEN}
```

([cyberuni/gherkin-cli run](https://github.com/cyberuni/gherkin-cli/actions/runs/31863702645/job/94961322151) — 0.2.0 is plainly on npm.)

The cyberuni copy carries a "Mirrors unional/.github… change both or neither" note, so this lands the same change here. Companion to cyberuni/.github#14; clibuilder/.github@945f4f71 had already dropped it.

Also corrects the stale cross-references in `bun-release-changeset-oidc.yml` and `pnpm-release-semantic-oidc.yml`, both of which cited the changesets workflow as the one that legitimately keeps `registry-url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
